### PR TITLE
[JENKINS-46634] Transformed widget pane style to class

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cloudstats/WidgetImpl/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/cloudstats/WidgetImpl/index.groovy
@@ -40,9 +40,10 @@ Jenkins j = app
 boolean cloudViews = Actionable.class.isAssignableFrom(Cloud.class)
 
 if (widget.displayed) {
+   style("#cloudstats { margin-bottom: 20px; }")
    CloudStatistics stats = CloudStatistics.get()
     def title = "<a href='${j.rootUrl}/${stats.getUrlName()}'>Cloud Statistics</a>"
-    l.pane(id: "cloudstats", width: 2, title: title, style: "margin-bottom: 20px") {
+    l.pane(id: "cloudstats", width: 2, title: title) {
         def index = stats.index
         index.healthByTemplate().each { String cloudName, Map<String, Health> templates ->
             tr {


### PR DESCRIPTION
Hi,

This is a small "cosmetic" fix for the cloud statistics widget. I noticed the widget was stuck to the build queue widget and I investigated why.

I have finally understood that the style parameter has no effect on pane element. So you have to use a css class to fix it.

