### PR TITLE
Require Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,13 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
+  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
   // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
   artifactCachingProxyEnabled: true,
-  // Test Java 8 with default Jenkins version, Java 11 with a recent LTS, Java 17 even more recent
+  // Test Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.375'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.361.4'],
-    [platform: 'windows', jdk:  '8']
+    [platform: 'linux',   jdk: '17', jenkins: '2.380'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'windows', jdk: '11']
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <surefire.useFile>false</surefire.useFile>
     <useBeta>true</useBeta>
     <spotbugs.effort>Max</spotbugs.effort>


### PR DESCRIPTION
## Require Java 11

Require Jenkins 2.361.4 or newer.

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ offers Jenkins 2.361.4 as one of the recommended versions.

Java 11 or newer is required for Jenkins 2.361.4 and for the most recent releases of the parent pom.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
