### PR TITLE
Reformat code with Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ActivityIndex.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ActivityIndex.java
@@ -105,10 +105,11 @@ public final class ActivityIndex {
     }
 
     /** Get activities owned by particular cloud and template. */
-    public @NonNull Collection<ProvisioningActivity> forTemplate(
-            @NonNull String cloud, @Nullable String template) {
+    public @NonNull Collection<ProvisioningActivity> forTemplate(@NonNull String cloud, @Nullable String template) {
         Map<String, Collection<ProvisioningActivity>> forCloud = byTemplate.get(cloud);
-        if (forCloud == null) return EMPTY;
+        if (forCloud == null) {
+            return EMPTY;
+        }
         Collection<ProvisioningActivity> ret = forCloud.get(template);
         return ret == null ? EMPTY : ret;
     }
@@ -125,8 +126,7 @@ public final class ActivityIndex {
 
     public @NonNull Map<String, Map<String, Health>> healthByTemplate() {
         HashMap<String, Map<String, Health>> ret = new HashMap<>(byTemplate.size());
-        for (Map.Entry<String, Map<String, Collection<ProvisioningActivity>>> entry :
-                byTemplate.entrySet()) {
+        for (Map.Entry<String, Map<String, Collection<ProvisioningActivity>>> entry : byTemplate.entrySet()) {
             HashMap<String, Health> tmpltret = new HashMap<>(entry.getValue().size());
             for (Map.Entry<String, Collection<ProvisioningActivity>> template :
                     entry.getValue().entrySet()) {
@@ -150,7 +150,9 @@ public final class ActivityIndex {
         List<ProvisioningActivity> samples = new ArrayList<>(as.size());
         for (ProvisioningActivity sample : as) {
             ProvisioningActivity.Phase currentPhase = sample.getCurrentPhase();
-            if (currentPhase != COMPLETED && currentPhase != OPERATING) continue;
+            if (currentPhase != COMPLETED && currentPhase != OPERATING) {
+                continue;
+            }
             samples.add(sample);
         }
         return samples;

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
@@ -78,8 +78,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
 
     /** The number of completed records to be stored. */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Not final for testing")
-    public static /*final*/ int ARCHIVE_RECORDS =
-            Integer.getInteger(ARCHIVE_RECORDS_PROPERTY_NAME, 100);
+    public static /*final*/ int ARCHIVE_RECORDS = Integer.getInteger(ARCHIVE_RECORDS_PROPERTY_NAME, 100);
 
     /**
      * All activities that are not in completed state.
@@ -98,9 +97,8 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
      * be explicitly synchronized.
      */
     @GuardedBy("active")
-    private /*final except for serialization*/ @NonNull CyclicThreadSafeCollection<
-                    ProvisioningActivity>
-            log = new CyclicThreadSafeCollection<>(ARCHIVE_RECORDS);
+    private /*final except for serialization*/ @NonNull CyclicThreadSafeCollection<ProvisioningActivity> log =
+            new CyclicThreadSafeCollection<>(ARCHIVE_RECORDS);
 
     /** Get the singleton instance. */
     public static @NonNull CloudStatistics get() {
@@ -122,10 +120,8 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         // unless we intervene here.
         for (ProvisioningActivity activity : getActivities()) {
             if (activity.getCurrentPhase() == ProvisioningActivity.Phase.PROVISIONING) {
-                PhaseExecutionAttachment attachment =
-                        new PhaseExecutionAttachment(
-                                ProvisioningActivity.Status.OK,
-                                "Provisioning interrupted by restart");
+                PhaseExecutionAttachment attachment = new PhaseExecutionAttachment(
+                        ProvisioningActivity.Status.OK, "Provisioning interrupted by restart");
                 activity.enter(ProvisioningActivity.Phase.COMPLETED);
                 attach(activity, ProvisioningActivity.Phase.COMPLETED, attachment);
                 archive(activity);
@@ -134,6 +130,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         }
     }
 
+    @Override
     public String getDisplayName() {
         return "Cloud Statistics";
     }
@@ -142,8 +139,12 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
     public String getIconFileName() {
         // This _needs_ to be done in getIconFileName only because of JENKINS-33683.
         Jenkins jenkins = Jenkins.get();
-        if (!jenkins.hasPermission(getRequiredPermission())) return null;
-        if (jenkins.clouds.isEmpty() && isEmpty()) return null;
+        if (!jenkins.hasPermission(getRequiredPermission())) {
+            return null;
+        }
+        if (jenkins.clouds.isEmpty() && isEmpty()) {
+            return null;
+        }
         return "graph.png";
     }
 
@@ -212,6 +213,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
      *     STATUS}.
      * @since 2.226 of Jenkins core
      */
+    @Override
     public String getCategoryName() {
         return "STATUS";
     }
@@ -230,9 +232,10 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
      *
      * @return The activity or null if rotated already.
      */
-    public @CheckForNull ProvisioningActivity getPotentiallyCompletedActivityFor(
-            ProvisioningActivity.Id id) {
-        if (id == null) return null;
+    public @CheckForNull ProvisioningActivity getPotentiallyCompletedActivityFor(ProvisioningActivity.Id id) {
+        if (id == null) {
+            return null;
+        }
 
         for (ProvisioningActivity activity : getActivities()) {
             if (activity.isFor(id)) {
@@ -245,7 +248,9 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
     /** Get "active" activity, missing activity will be logged. */
     public @CheckForNull ProvisioningActivity getActivityFor(ProvisioningActivity.Id id) {
         ProvisioningActivity activity = getPotentiallyCompletedActivityFor(id);
-        if (activity != null) return activity;
+        if (activity != null) {
+            return activity;
+        }
 
         LOGGER.log(Level.WARNING, "No activity tracked for " + id, new IllegalStateException());
         return null;
@@ -253,7 +258,9 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
 
     public @CheckForNull ProvisioningActivity getActivityFor(TrackedItem item) {
         ProvisioningActivity.Id id = item.getId();
-        if (id == null) return null;
+        if (id == null) {
+            return null;
+        }
         return getActivityFor(id);
     }
 
@@ -289,7 +296,9 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         attachment.getClass();
 
         // No UI
-        if (attachment.getUrlName() == null) return null;
+        if (attachment.getUrlName() == null) {
+            return null;
+        }
 
         StringBuilder url = new StringBuilder("/cloud-stats/");
         url.append("activity/").append(activity.getId().getFingerprint()).append('/');
@@ -316,8 +325,11 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         persist();
     }
 
+    @Override
     public void save() throws IOException {
-        if (BulkChange.contains(this)) return;
+        if (BulkChange.contains(this)) {
+            return;
+        }
 
         getConfigFile().write(this);
     }
@@ -394,11 +406,9 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
             FilePath configFile = new FilePath(getConfigFile().getFile());
             try {
                 if (configFile.exists()) {
-                    FilePath target =
-                            new FilePath(new File(configFile.getRemote() + ".bak-JENKINS-44929"));
+                    FilePath target = new FilePath(new File(configFile.getRemote() + ".bak-JENKINS-44929"));
                     configFile.renameTo(target);
-                    LOGGER.warning(
-                            msg + " Please file a bug report attaching " + target.getRemote());
+                    LOGGER.warning(msg + " Please file a bug report attaching " + target.getRemote());
                 } else {
                     LOGGER.warning(msg + " " + configFile.getRemote() + " not found");
                 }
@@ -413,7 +423,10 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
             log = new CyclicThreadSafeCollection<>(ARCHIVE_RECORDS);
             int added = 0;
             for (ProvisioningActivity pa : existing) {
-                if (added > ARCHIVE_RECORDS) break; // Prevent adding more when shrinking
+                if (added > ARCHIVE_RECORDS) {
+                    // Prevent adding more when shrinking
+                    break;
+                }
                 log.add(pa);
                 added++;
             }
@@ -425,9 +438,8 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
     /*package for testing*/ XmlFile getConfigFile() {
         return new XmlFile(
                 Jenkins.XSTREAM,
-                new File(
-                        new File(Jenkins.getInstance().root, getClass().getCanonicalName() + ".xml")
-                                .getAbsolutePath()));
+                new File(new File(Jenkins.getInstance().root, getClass().getCanonicalName() + ".xml")
+                        .getAbsolutePath()));
     }
 
     private void archive(ProvisioningActivity activity) {
@@ -454,8 +466,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
 
         @Override
         @Restricted(DoNotUse.class)
-        public void onStarted(
-                Cloud cloud, Label label, Collection<NodeProvisioner.PlannedNode> plannedNodes) {
+        public void onStarted(Cloud cloud, Label label, Collection<NodeProvisioner.PlannedNode> plannedNodes) {
             BulkChange change = new BulkChange(stats);
             try {
                 boolean changed = false;
@@ -513,8 +524,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
          *
          * <p>The method should be called before the node is added to Jenkins.
          */
-        public @CheckForNull ProvisioningActivity onComplete(
-                @NonNull ProvisioningActivity.Id id, @NonNull Node node) {
+        public @CheckForNull ProvisioningActivity onComplete(@NonNull ProvisioningActivity.Id id, @NonNull Node node) {
             ProvisioningActivity activity = stats.getActivityFor(id);
             if (activity != null) {
                 activity.rename(node.getDisplayName());
@@ -551,14 +561,15 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
                 stats.attach(
                         activity,
                         ProvisioningActivity.Phase.PROVISIONING,
-                        new PhaseExecutionAttachment.ExceptionAttachment(
-                                ProvisioningActivity.Status.FAIL, throwable));
+                        new PhaseExecutionAttachment.ExceptionAttachment(ProvisioningActivity.Status.FAIL, throwable));
             }
             return activity;
         }
 
         public static ProvisioningListener get() {
-            return Jenkins.getInstance().getExtensionList(ProvisioningListener.class).get(0);
+            return Jenkins.getInstance()
+                    .getExtensionList(ProvisioningListener.class)
+                    .get(0);
         }
     }
 
@@ -571,9 +582,13 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         @Override
         public void preLaunch(Computer c, TaskListener taskListener) {
             ProvisioningActivity.Id id = getIdFor(c);
-            if (id == null) return;
+            if (id == null) {
+                return;
+            }
             ProvisioningActivity activity = stats.getActivityFor(id);
-            if (activity == null) return;
+            if (activity == null) {
+                return;
+            }
 
             // Do not enter second time on relaunch
             boolean entered = activity.enterIfNotAlready(ProvisioningActivity.Phase.LAUNCHING);
@@ -585,9 +600,13 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         @Override
         public void onLaunchFailure(Computer c, TaskListener taskListener) {
             ProvisioningActivity.Id id = getIdFor(c);
-            if (id == null) return;
+            if (id == null) {
+                return;
+            }
             ProvisioningActivity activity = stats.getActivityFor(id);
-            if (activity == null) return;
+            if (activity == null) {
+                return;
+            }
 
             // TODO attach details
             // ...
@@ -596,9 +615,13 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         @Override
         public void onOnline(Computer c, TaskListener listener) {
             ProvisioningActivity.Id id = getIdFor(c);
-            if (id == null) return;
+            if (id == null) {
+                return;
+            }
             ProvisioningActivity activity = stats.getActivityFor(id);
-            if (activity == null) return;
+            if (activity == null) {
+                return;
+            }
 
             // Do not enter second time on relaunch
             boolean entered = activity.enterIfNotAlready(ProvisioningActivity.Phase.OPERATING);
@@ -633,24 +656,27 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
 
             ArrayList<ProvisioningActivity> completed = new ArrayList<>();
             for (ProvisioningActivity activity : stats.getRetainedActivities()) {
-                Map<ProvisioningActivity.Phase, PhaseExecution> executions =
-                        activity.getPhaseExecutions();
+                Map<ProvisioningActivity.Phase, PhaseExecution> executions = activity.getPhaseExecutions();
 
                 if (executions.get(ProvisioningActivity.Phase.COMPLETED) != null) {
                     completed.add(activity);
                     continue; // Completed already
                 }
-                assert activity.getStatus()
-                        != ProvisioningActivity.Status
-                                .FAIL; // Should be completed already if failed
+                // Should be completed already if failed
+                assert activity.getStatus() != ProvisioningActivity.Status.FAIL;
 
                 // TODO there is still a chance some activity will never be recognised as completed
                 // when provisioning
                 // completes without error and launching never starts for some reason
-                if (executions.get(ProvisioningActivity.Phase.LAUNCHING) == null)
-                    continue; // Still provisioning
+                if (executions.get(ProvisioningActivity.Phase.LAUNCHING) == null) {
+                    // Still provisioning
+                    continue;
+                }
 
-                if (trackedExisting.contains(activity.getId())) continue; // Still operating
+                if (trackedExisting.contains(activity.getId())) {
+                    // Still operating
+                    continue;
+                }
 
                 activity.enter(ProvisioningActivity.Phase.COMPLETED);
                 completed.add(activity);
@@ -674,13 +700,21 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         // Reflect renames so the name of the activity tracks the agent name
         @Override
         protected void onUpdated(@NonNull Node oldOne, @NonNull Node newOne) {
-            if (oldOne.getNodeName().equals(newOne.getNodeName())) return; // Not renamed
+            if (oldOne.getNodeName().equals(newOne.getNodeName())) {
+                // Not renamed
+                return;
+            }
 
             ProvisioningActivity.Id id = getIdFor(oldOne);
-            if (id == null) return; // Not tracked
+            if (id == null) {
+                // Not tracked
+                return;
+            }
 
             ProvisioningActivity activity = stats.getActivityFor(id);
-            if (activity == null) return;
+            if (activity == null) {
+                return;
+            }
 
             activity.rename(newOne.getNodeName());
             stats.persist();
@@ -689,10 +723,15 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         @Override
         protected void onDeleted(@NonNull Node node) {
             ProvisioningActivity.Id id = getIdFor(node);
-            if (id == null) return; // Not tracked
+            if (id == null) {
+                // Not tracked
+                return;
+            }
 
             ProvisioningActivity activity = stats.getActivityFor(id);
-            if (activity == null) return;
+            if (activity == null) {
+                return;
+            }
 
             // The phase might already been entered in case cloud plugins needed to to add an
             // attachment to the phase.
@@ -707,8 +746,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         }
     }
 
-    private static @CheckForNull ProvisioningActivity.Id getIdFor(
-            NodeProvisioner.PlannedNode plannedNode) {
+    private static @CheckForNull ProvisioningActivity.Id getIdFor(NodeProvisioner.PlannedNode plannedNode) {
         if (!(plannedNode instanceof TrackedItem)) {
             logTypeNotSupported(plannedNode.getClass());
             return null;
@@ -718,7 +756,9 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
     }
 
     private static @CheckForNull ProvisioningActivity.Id getIdFor(Node node) {
-        if (node instanceof Jenkins) return null;
+        if (node instanceof Jenkins) {
+            return null;
+        }
 
         if (!(node instanceof TrackedItem)) {
             LOGGER.info("No support for cloud-stats-plugin by " + node.getClass());
@@ -729,8 +769,12 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
     }
 
     private static @CheckForNull ProvisioningActivity.Id getIdFor(Computer computer) {
-        if (computer instanceof Jenkins.MasterComputer) return null;
-        if (!(computer instanceof AbstractCloudComputer)) return null;
+        if (computer instanceof Jenkins.MasterComputer) {
+            return null;
+        }
+        if (!(computer instanceof AbstractCloudComputer)) {
+            return null;
+        }
 
         if (!(computer instanceof TrackedItem)) {
             logTypeNotSupported(computer.getClass());
@@ -747,6 +791,5 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         }
     }
 
-    private static final Set<Class> loggedUnsupportedTypes =
-            Collections.synchronizedSet(new HashSet<>());
+    private static final Set<Class> loggedUnsupportedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CyclicThreadSafeCollection.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CyclicThreadSafeCollection.java
@@ -57,7 +57,9 @@ public class CyclicThreadSafeCollection<E> implements Collection<E> {
     private @Nonnegative int size = 0;
 
     public CyclicThreadSafeCollection(int capacity) {
-        if (capacity < 0) throw new IllegalArgumentException("Capacity must be non-negative");
+        if (capacity < 0) {
+            throw new IllegalArgumentException("Capacity must be non-negative");
+        }
 
         this.data = CyclicThreadSafeCollection.newArray(capacity);
     }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/Health.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/Health.java
@@ -66,7 +66,7 @@ public final class Health {
             }
         }
 
-        return new Report((success * 100 / all));
+        return new Report(success * 100 / all);
     }
 
     /**
@@ -79,7 +79,9 @@ public final class Health {
      * ones.
      */
     public Report getCurrent() {
-        if (samples.isEmpty()) return new Report(Float.NaN);
+        if (samples.isEmpty()) {
+            return new Report(Float.NaN);
+        }
 
         // Base the relative wights on the newest sample. It is important for older samples not to
         // outweight the recent
@@ -130,8 +132,12 @@ public final class Health {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             Report report = (Report) o;
 
@@ -140,12 +146,14 @@ public final class Health {
 
         @Override
         public int hashCode() {
-            return (percent != +0.0f ? Float.floatToIntBits(percent) : 0);
+            return percent != +0.0f ? Float.floatToIntBits(percent) : 0;
         }
 
         @Override
         public String toString() {
-            if (Float.isNaN(percent)) return "?";
+            if (Float.isNaN(percent)) {
+                return "?";
+            }
             return FORMAT.format(percent);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
@@ -51,8 +51,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * started launching, plugin can still append provisioning log.
  */
 public final class PhaseExecution implements ModelObject {
-    private final @NonNull List<PhaseExecutionAttachment> attachments =
-            new CopyOnWriteArrayList<>();
+    private final @NonNull List<PhaseExecutionAttachment> attachments = new CopyOnWriteArrayList<>();
     private final long started;
     private final @NonNull ProvisioningActivity.Phase phase;
 
@@ -69,8 +68,7 @@ public final class PhaseExecution implements ModelObject {
         return Collections.unmodifiableList(attachments);
     }
 
-    public @NonNull <T extends PhaseExecutionAttachment> List<T> getAttachments(
-            @NonNull Class<T> type) {
+    public @NonNull <T extends PhaseExecutionAttachment> List<T> getAttachments(@NonNull Class<T> type) {
         List<T> out = new ArrayList<>();
         for (PhaseExecutionAttachment attachment : getAttachments()) {
             if (type.isInstance(attachment)) {
@@ -119,14 +117,19 @@ public final class PhaseExecution implements ModelObject {
     @Restricted(NoExternalUse.class)
     public @CheckForNull String getUrlName(@NonNull PhaseExecutionAttachment attachment) {
         String urlName = attachment.getUrlName();
-        if (urlName == null) return null;
+        if (urlName == null) {
+            return null;
+        }
 
-        if (!attachments.contains(attachment))
+        if (!attachments.contains(attachment)) {
             throw new IllegalArgumentException("Attachment not present in current execution");
+        }
 
         int cntr = 0;
         for (PhaseExecutionAttachment a : attachments) {
-            if (a.equals(attachment)) break;
+            if (a.equals(attachment)) {
+                break;
+            }
 
             if (urlName.equals(a.getUrlName())) {
                 cntr++;
@@ -155,13 +158,19 @@ public final class PhaseExecution implements ModelObject {
         }
 
         // Fail early
-        if (n > attachments.size()) return null;
+        if (n > attachments.size()) {
+            return null;
+        }
 
         int cntr = 0;
         for (PhaseExecutionAttachment a : attachments) {
-            if (!urlName.equals(a.getUrlName())) continue;
+            if (!urlName.equals(a.getUrlName())) {
+                continue;
+            }
 
-            if (cntr == n) return a;
+            if (cntr == n) {
+                return a;
+            }
 
             cntr++;
         }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
@@ -40,8 +40,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
     private final @NonNull ProvisioningActivity.Status status;
     private final @NonNull String title;
 
-    public PhaseExecutionAttachment(
-            @NonNull ProvisioningActivity.Status status, @NonNull String title) {
+    public PhaseExecutionAttachment(@NonNull ProvisioningActivity.Status status, @NonNull String title) {
         this.status = status;
         this.title = title;
     }
@@ -71,7 +70,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
     @Override
     public @NonNull String getDisplayName() {
         String title = getTitle();
-        return title.length() < 50 ? title : (title.substring(0, 49) + "…");
+        return title.length() < 50 ? title : title.substring(0, 49) + "…";
     }
 
     /**
@@ -89,13 +88,16 @@ public class PhaseExecutionAttachment implements Action, Serializable {
         public static final long serialVersionUID = 0;
 
         // Replaced by text field
-        @Deprecated private transient Throwable throwable;
+        @Deprecated
+        private transient Throwable throwable;
 
         private /*final*/ @NonNull String text;
 
         @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
         private Object readResolve() {
-            if (text != null) return this;
+            if (text != null) {
+                return this;
+            }
 
             // Failed to deserialize
             if (throwable == null) {
@@ -107,8 +109,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
             return this;
         }
 
-        public ExceptionAttachment(
-                @NonNull ProvisioningActivity.Status status, @NonNull Throwable throwable) {
+        public ExceptionAttachment(@NonNull ProvisioningActivity.Status status, @NonNull Throwable throwable) {
             super(status, extractTitle(throwable));
             this.text = Functions.printThrowable(throwable);
         }
@@ -119,11 +120,12 @@ public class PhaseExecutionAttachment implements Action, Serializable {
             String message = throwable.getMessage();
 
             // The message might be empty (NPE for example) so get the type at least
-            if (message == null) return throwable.getClass().getSimpleName();
+            if (message == null) {
+                return throwable.getClass().getSimpleName();
+            }
 
             // "NoSuchFileException: /foo/bar"
-            if (throwable instanceof NoSuchFileException
-                    || throwable instanceof FileNotFoundException) {
+            if (throwable instanceof NoSuchFileException || throwable instanceof FileNotFoundException) {
                 return throwable.getClass().getSimpleName() + ": " + throwable.getMessage();
             }
 
@@ -131,9 +133,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
         }
 
         public ExceptionAttachment(
-                @NonNull ProvisioningActivity.Status status,
-                @NonNull String title,
-                @NonNull Throwable throwable) {
+                @NonNull ProvisioningActivity.Status status, @NonNull String title, @NonNull Throwable throwable) {
             super(status, title);
             this.text = Functions.printThrowable(throwable);
         }
@@ -150,6 +150,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
             return text;
         }
 
+        @Override
         public String toString() {
             return "Exception attachment: " + getTitle();
         }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -102,10 +102,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
          *     known ahead, it can be <code>null</code> cloud stats plugin will update it once it
          *     will be known.
          */
-        public Id(
-                @NonNull String cloudName,
-                @CheckForNull String templateName,
-                @CheckForNull String nodeName) {
+        public Id(@NonNull String cloudName, @CheckForNull String templateName, @CheckForNull String nodeName) {
             this.cloudName = cloudName;
             this.templateName = templateName;
             this.nodeName = nodeName;
@@ -164,8 +161,12 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             Id id = (Id) o;
             return fingerprint == id.fingerprint;
         }
@@ -178,8 +179,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         @Override
         public String toString() {
             return String.format(
-                    "ProvisioningActivity for %s/%s/%s (%d)",
-                    cloudName, templateName, nodeName, fingerprint);
+                    "ProvisioningActivity for %s/%s/%s (%d)", cloudName, templateName, nodeName, fingerprint);
         }
     }
 
@@ -266,16 +266,24 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     public @NonNull PhaseExecution getCurrentPhaseExecution() {
         synchronized (progress) {
             PhaseExecution ex = progress.get(Phase.COMPLETED);
-            if (ex != null) return ex;
+            if (ex != null) {
+                return ex;
+            }
 
             ex = progress.get(Phase.OPERATING);
-            if (ex != null) return ex;
+            if (ex != null) {
+                return ex;
+            }
 
             ex = progress.get(Phase.LAUNCHING);
-            if (ex != null) return ex;
+            if (ex != null) {
+                return ex;
+            }
 
             ex = progress.get(Phase.PROVISIONING);
-            if (ex != null) return ex;
+            if (ex != null) {
+                return ex;
+            }
 
             throw new IllegalStateException("Unknown provisioning state of " + getDisplayName());
         }
@@ -295,7 +303,9 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         synchronized (progress) {
             Status status = Status.OK;
             for (PhaseExecution e : progress.values()) {
-                if (e == null) continue;
+                if (e == null) {
+                    continue;
+                }
                 Status s = e.getStatus();
                 if (status.ordinal() < s.ordinal()) {
                     status = s;
@@ -312,19 +322,18 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      */
     public void enter(@NonNull Phase phase) {
         synchronized (progress) {
-            if (progress.get(phase) != null)
+            if (progress.get(phase) != null) {
                 throw new IllegalStateException("The phase " + phase + " has already started");
+            }
 
             final Phase currentPhase = getCurrentPhase();
-            if (currentPhase.compareTo(phase) >= 0)
-                throw new IllegalStateException(
-                        "The phase " + getCurrentPhase() + " has already started");
+            if (currentPhase.compareTo(phase) >= 0) {
+                throw new IllegalStateException("The phase " + getCurrentPhase() + " has already started");
+            }
 
             progress.put(phase, new PhaseExecution(phase));
 
-            if (phase == Phase.COMPLETED
-                    && currentPhase != Phase.OPERATING
-                    && getStatus() == Status.OK) {
+            if (phase == Phase.COMPLETED && currentPhase != Phase.OPERATING && getStatus() == Status.OK) {
                 PhaseExecutionAttachment attachment =
                         new PhaseExecutionAttachment(Status.WARN, PREMATURE_COMPLETION_DETECTED);
                 progress.get(Phase.COMPLETED).attach(attachment);
@@ -349,8 +358,9 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     public boolean enterIfNotAlready(@NonNull Phase phase) {
         synchronized (progress) {
             // Entered or skipped
-            if (progress.get(phase) != null || getCurrentPhase().compareTo(phase) >= 0)
+            if (progress.get(phase) != null || getCurrentPhase().compareTo(phase) >= 0) {
                 return false;
+            }
             progress.put(phase, new PhaseExecution(phase));
         }
         return true;
@@ -363,8 +373,9 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     @Restricted(NoExternalUse.class)
     /*package*/ void attach(Phase phase, PhaseExecutionAttachment attachment) {
         PhaseExecution execution = getPhaseExecution(phase);
-        if (execution == null)
+        if (execution == null) {
             throw new IllegalArgumentException("Phase " + phase + " not entered yet");
+        }
         execution.attach(attachment);
     }
 
@@ -387,8 +398,9 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      */
     @Restricted(NoExternalUse.class)
     /*package*/ void rename(@NonNull String newName) {
-        if (Util.fixEmptyAndTrim(newName) == null)
+        if (Util.fixEmptyAndTrim(newName) == null) {
             throw new IllegalArgumentException("Unable to rename to empty string");
+        }
         synchronized (id) {
             name = newName;
         }
@@ -408,20 +420,24 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     @Restricted(NoExternalUse.class) // Stapler only
     public long getDuration(@NonNull PhaseExecution execution) {
         Phase phase = execution.getPhase();
-        if (phase == Phase.COMPLETED) throw new IllegalArgumentException();
+        if (phase == Phase.COMPLETED) {
+            throw new IllegalArgumentException();
+        }
 
         // Find any later nonnull execution
         PhaseExecution next = null;
         for (Phase p : Phase.values()) {
-            if (p.ordinal() <= phase.ordinal()) continue;
+            if (p.ordinal() <= phase.ordinal()) {
+                continue;
+            }
             next = getPhaseExecution(p);
-            if (next != null) break;
+            if (next != null) {
+                break;
+            }
         }
 
         long started = execution.getStartedTimestamp();
-        return next != null
-                ? next.getStartedTimestamp() - started
-                : -(System.currentTimeMillis() - started);
+        return next != null ? next.getStartedTimestamp() - started : -(System.currentTimeMillis() - started);
     }
 
     public boolean isFor(Id id) {
@@ -440,9 +456,15 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
 
     @Override
     public boolean equals(Object o) {
-        if (o == null) return false;
-        if (o == this) return true;
-        if (!o.getClass().equals(getClass())) return false;
+        if (o == null) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        if (!o.getClass().equals(getClass())) {
+            return false;
+        }
         ProvisioningActivity rhs = (ProvisioningActivity) o;
         return id.equals(rhs.id);
     }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/TrackedPlannedNode.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/TrackedPlannedNode.java
@@ -44,8 +44,7 @@ public class TrackedPlannedNode extends PlannedNode implements TrackedItem {
 
     private final @NonNull ProvisioningActivity.Id id;
 
-    public TrackedPlannedNode(
-            @NonNull ProvisioningActivity.Id id, int numExecutors, @NonNull Future<Node> future) {
+    public TrackedPlannedNode(@NonNull ProvisioningActivity.Id id, int numExecutors, @NonNull Future<Node> future) {
         super(extractTemporaryName(id), future, numExecutors);
 
         this.id = id;
@@ -63,6 +62,7 @@ public class TrackedPlannedNode extends PlannedNode implements TrackedItem {
         return name;
     }
 
+    @Override
     public @NonNull ProvisioningActivity.Id getId() {
         return id;
     }

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/ActivityIndexTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/ActivityIndexTest.java
@@ -49,18 +49,12 @@ public class ActivityIndexTest {
 
     @Test
     public void content() {
-        ActivityIndex index =
-                new ActivityIndex(
-                        Arrays.asList(
-                                new ProvisioningActivity(new ProvisioningActivity.Id("A", "a")),
-                                new ProvisioningActivity(
-                                        new ProvisioningActivity.Id("A", "b", "x")),
-                                new ProvisioningActivity(
-                                        new ProvisioningActivity.Id("B", "a", "xxxx")),
-                                new ProvisioningActivity(
-                                        new ProvisioningActivity.Id("C", null, "c")),
-                                new ProvisioningActivity(
-                                        new ProvisioningActivity.Id("C", null, "cc"))));
+        ActivityIndex index = new ActivityIndex(Arrays.asList(
+                new ProvisioningActivity(new ProvisioningActivity.Id("A", "a")),
+                new ProvisioningActivity(new ProvisioningActivity.Id("A", "b", "x")),
+                new ProvisioningActivity(new ProvisioningActivity.Id("B", "a", "xxxx")),
+                new ProvisioningActivity(new ProvisioningActivity.Id("C", null, "c")),
+                new ProvisioningActivity(new ProvisioningActivity.Id("C", null, "cc"))));
         assertThat(index.byCloud().keySet(), containsInAnyOrder("A", "B", "C"));
         assertThat(index.byCloud().get("A").size(), equalTo(2));
         assertThat(index.byCloud().get("B").size(), equalTo(1));
@@ -80,25 +74,19 @@ public class ActivityIndexTest {
 
     @Test
     public void activitiesNotCompletedOrOperatingAreIgnoredForHealth() {
-        ActivityIndex index =
-                new ActivityIndex(
-                        Arrays.asList(
-                                enter(
-                                        new ProvisioningActivity(
-                                                new ProvisioningActivity.Id("P", "p")),
-                                        ProvisioningActivity.Phase.PROVISIONING),
-                                enter(
-                                        new ProvisioningActivity(
-                                                new ProvisioningActivity.Id("L", "l")),
-                                        ProvisioningActivity.Phase.LAUNCHING),
-                                enter(
-                                        new ProvisioningActivity(
-                                                new ProvisioningActivity.Id("O", "o")),
-                                        ProvisioningActivity.Phase.OPERATING),
-                                enter(
-                                        new ProvisioningActivity(
-                                                new ProvisioningActivity.Id("C", "c")),
-                                        ProvisioningActivity.Phase.COMPLETED)));
+        ActivityIndex index = new ActivityIndex(Arrays.asList(
+                enter(
+                        new ProvisioningActivity(new ProvisioningActivity.Id("P", "p")),
+                        ProvisioningActivity.Phase.PROVISIONING),
+                enter(
+                        new ProvisioningActivity(new ProvisioningActivity.Id("L", "l")),
+                        ProvisioningActivity.Phase.LAUNCHING),
+                enter(
+                        new ProvisioningActivity(new ProvisioningActivity.Id("O", "o")),
+                        ProvisioningActivity.Phase.OPERATING),
+                enter(
+                        new ProvisioningActivity(new ProvisioningActivity.Id("C", "c")),
+                        ProvisioningActivity.Phase.COMPLETED)));
 
         Map<String, Health> hc = index.healthByCloud();
         assertThat(hc.get("P").getOverall().getPercentage(), equalTo(Float.NaN));
@@ -121,8 +109,7 @@ public class ActivityIndexTest {
         assertThat(index.templateHealth("C", "c").getOverall().getPercentage(), equalTo(100F));
     }
 
-    private ProvisioningActivity enter(
-            ProvisioningActivity provisioningActivity, ProvisioningActivity.Phase p) {
+    private ProvisioningActivity enter(ProvisioningActivity provisioningActivity, ProvisioningActivity.Phase p) {
         provisioningActivity.enterIfNotAlready(p);
         return provisioningActivity;
     }

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/HealthTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/HealthTest.java
@@ -152,11 +152,12 @@ public class HealthTest {
 
         assertEquals(0, health(failure(0)).getCurrent().getPercentage(), 0F);
         assertEquals(50, health(success(0), failure(1)).getCurrent().getPercentage(), 1F);
-        assertEquals(
-                66, health(success(0), success(1), failure(2)).getCurrent().getPercentage(), 2F);
+        assertEquals(66, health(success(0), success(1), failure(2)).getCurrent().getPercentage(), 2F);
         assertEquals(
                 75,
-                health(success(0), success(1), success(2), failure(3)).getCurrent().getPercentage(),
+                health(success(0), success(1), success(2), failure(3))
+                        .getCurrent()
+                        .getPercentage(),
                 2F);
 
         assertEquals(57, health(success(0), failure(10)).getCurrent().getPercentage(), 1F);

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachmentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachmentTest.java
@@ -45,7 +45,6 @@ public class PhaseExecutionAttachmentTest {
         assertEquals(
                 "NoSuchFileException: /foo: Some reason",
                 extractTitle(new NoSuchFileException("/foo", null, "Some reason")));
-        assertEquals(
-                "FileNotFoundException: /foo", extractTitle(new FileNotFoundException("/foo")));
+        assertEquals("FileNotFoundException: /foo", extractTitle(new FileNotFoundException("/foo")));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivityTest.java
@@ -38,8 +38,7 @@ import org.jvnet.hudson.test.Issue;
 
 public class ProvisioningActivityTest {
 
-    private static final ProvisioningActivity.Id DUMMY_ID =
-            new ProvisioningActivity.Id("Fake cloud");
+    private static final ProvisioningActivity.Id DUMMY_ID = new ProvisioningActivity.Id("Fake cloud");
 
     @Test
     public void id() {
@@ -219,8 +218,7 @@ public class ProvisioningActivityTest {
     public void enteringCompletedPhaseWithoutOperationShouldBeWarningState() {
         ProvisioningActivity pa = new ProvisioningActivity(new ProvisioningActivity.Id("cld"));
         final PhaseExecutionAttachment failedAttachment =
-                new PhaseExecutionAttachment(
-                        ProvisioningActivity.Status.FAIL, "Failed intentionally");
+                new PhaseExecutionAttachment(ProvisioningActivity.Status.FAIL, "Failed intentionally");
 
         pa.enter(COMPLETED);
         assertEquals(WARN, pa.getPhaseExecution(COMPLETED).getStatus());
@@ -259,8 +257,7 @@ public class ProvisioningActivityTest {
         assertThat(pa.getPhaseExecution(COMPLETED).getAttachments(), hasSize(0));
     }
 
-    private PhaseExecution enter(
-            ProvisioningActivity activity, ProvisioningActivity.Phase phase, long started) {
+    private PhaseExecution enter(ProvisioningActivity activity, ProvisioningActivity.Phase phase, long started) {
         PhaseExecution execution = new PhaseExecution(phase, started);
         activity.enter(execution);
         return execution;

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/StatsWidgetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/StatsWidgetTest.java
@@ -34,7 +34,8 @@ import org.jvnet.hudson.test.recipes.PresetData;
 
 public class StatsWidgetTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void showWhenCloudsConfigured() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/TestCloud.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/TestCloud.java
@@ -65,8 +65,7 @@ public final class TestCloud extends Cloud {
         provision.id = new ProvisioningActivity.Id(name, null, name + "-agent-" + i);
 
         return Collections.singletonList(
-                new TrackedPlannedNode(
-                        provision.id, 1, Computer.threadPoolForRemoting.submit(provision)));
+                new TrackedPlannedNode(provision.id, 1, Computer.threadPoolForRemoting.submit(provision)));
     }
 
     @Override


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted `plugin-compat-tester` this way in https://github.com/jenkinsci/plugin-compat-tester/pull/506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity.