### PR TITLE
Implement WidgetFactory for CloudSet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.404-rc33641.c79f96b_b_6874</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/StatsWidget.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/StatsWidget.java
@@ -23,9 +23,14 @@
  */
 package org.jenkinsci.plugins.cloudstats;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.widgets.Widget;
+import java.util.Collection;
+import java.util.List;
+import jenkins.agents.CloudSet;
 import jenkins.model.Jenkins;
+import jenkins.widgets.WidgetFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -33,12 +38,41 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
  * @author ogondza.
  */
 @Restricted(DoNotUse.class)
-@Extension(ordinal = 300) // Above queue
 public class StatsWidget extends Widget {
+
+    private final String ownerUrl;
+
+    public StatsWidget(String ownerUrl) {
+        this.ownerUrl = ownerUrl;
+    }
+
+    @Override
+    protected String getOwnerUrl() {
+        return ownerUrl;
+    }
 
     public boolean isDisplayed() {
         Jenkins instance = Jenkins.get();
         return !instance.clouds.isEmpty()
                 && instance.hasPermission(CloudStatistics.get().getRequiredPermission());
+    }
+
+    @Extension
+    public static class FactoryImpl extends WidgetFactory<CloudSet, StatsWidget> {
+        @Override
+        public Class<CloudSet> type() {
+            return CloudSet.class;
+        }
+
+        @Override
+        public Class<StatsWidget> widgetType() {
+            return StatsWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<StatsWidget> createFor(@NonNull CloudSet target) {
+            return List.of(new StatsWidget(target.getUrlName() + "/"));
+        }
     }
 }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/7932

This lets the plugin leverage the new extension point to show the stats widgets in the CloudSet view where it makes sense the most.

Screenshot (didn't have relevant data but that lets you see the layout)

![Capture d’écran 2023-05-05 à 17 36 25](https://user-images.githubusercontent.com/171459/236503394-e5666edd-c118-4f9f-b699-c93572405045.png)


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
