### PR TITLE
`NullPointerException`: Cannot get property `cloudName` on null object

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cloudstats/CloudAction/box.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/cloudstats/CloudAction/box.groovy
@@ -11,7 +11,7 @@ CloudAction action = my
 Jenkins jenkins = app
 
 def c = jenkins.getComputers().grep {
-    it instanceof TrackedItem && it.id.cloudName == action.cloud.name
+    it instanceof TrackedItem && it.id != null && it.id.cloudName == action.cloud.name
 }
 
 j.executors(computers: c, ajax: false)


### PR DESCRIPTION
While doing various changes in `docker-plugin` recently I observed:

```
May 26 11:57:46 basil-desktop jenkins[2834084]: Caused by: java.lang.NullPointerException: Cannot get property 'cloudName' on null object
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:60)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:190)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.NullCallSite.getProperty(NullCallSite.java:46)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:299)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.jenkinsci.plugins.cloudstats.CloudAction.box$_run_closure1.doCall(box.groovy:14)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at java.base/java.lang.reflect.Method.invoke(Method.java:578)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:264)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:41)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.BooleanReturningMethodInvoker.invoke(BooleanReturningMethodInvoker.java:51)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper.call(BooleanClosureWrapper.java:53)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at groovy.lang.Closure.isCase(Closure.java:404)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at java.base/java.lang.reflect.Method.invoke(Method.java:578)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:264)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:41)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.BooleanReturningMethodInvoker.invoke(BooleanReturningMethodInvoker.java:51)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.DefaultGroovyMethods.grep(DefaultGroovyMethods.java:2640)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.dgm$302.invoke(Unknown Source)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:128)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.jenkinsci.plugins.cloudstats.CloudAction.box.run(box.groovy:13)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.kohsuke.stapler.jelly.groovy.GroovierJellyScript.run(GroovierJellyScript.java:94)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.kohsuke.stapler.jelly.groovy.GroovierJellyScript.run(GroovierJellyScript.java:71)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.kohsuke.stapler.jelly.IncludeTag.doTag(IncludeTag.java:172)
May 26 11:57:46 basil-desktop jenkins[2834084]:         at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:265)
May 26 11:57:46 basil-desktop jenkins[2834084]:         ... 143 more
```

While I cannot remember how to reproduce this, the cause is very clear from the stack trace. `TrackedItem#getId` is declared in this repository to be `Nullable`, a fact which `docker-plugin` makes use of in its implementation. But one of this repository's Groovy views does not respect this. The fix is clearly to add a null check.