### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
   directory: /
   schedule:
     interval: monthly
-  ignore:
-    # TODO: Remove when jenkins.version >= 2.387.3
-    # The 3.1.10 release requires Jenkins 2.387.3 or newer
-    - dependency-name: "org.jenkins-ci.plugins:matrix-auth"
-      versions: [">3.1.9"]

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
@@ -51,25 +51,28 @@
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2329.v078520e55c19</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.2.0</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- JTH ships a newer version -->
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
-      <!-- Needed by JTH -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>3.1.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Require Jenkins 2.387.3 or newer so that the plugin bill of materials can provide the version of matrix-auth needed for the tests.

Remove the unused exclusion of hamcrest dependency.

### Testing done

Confirmed that tests pass on my Java 11 environment.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
