### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,13 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  // Test Java 11 with minimum Jenkins version
+  // Test Java 17 with a more recent version
+  // Test Java 21 with a more recent version
   configurations: [
     [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
     [platform: 'linux',   jdk: '17'],
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: '17', jenkins: '2.389'],
   ]
 )


### PR DESCRIPTION
## Test with Java 21

Java 21 will release Sep 19, 2023.  We'd like to be ready to support it with a Jenkins weekly release soon after release.  Testing plugins with Java 21 early access is good preparation for eventual support of Java 21.

### Testing done

Confirmed tests pass with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
