### PR TITLE
Update CloudStatistics icon

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudAction.java
@@ -55,7 +55,7 @@ public class CloudAction implements Action {
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return "graph.png";
+        return "symbol-analytics";
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
@@ -145,7 +145,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         if (jenkins.clouds.isEmpty() && isEmpty()) {
             return null;
         }
-        return "graph.png";
+        return "symbol-analytics";
     }
 
     @Override


### PR DESCRIPTION
Update the icon of the "Cloud Statistics" menu under "Manage Jenkins".
The idea is to harmonize the look and feel of the page since most other plugins and especially the core functions there also use these kind of icons.

I opted with built-in icons from [Jenkins core](https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols) to not introduce any new dependencies.

### Testing done
Manual starting local instance, comparing results.

**Before**
![before](https://github.com/jenkinsci/cloud-stats-plugin/assets/49242855/88d9249e-c740-42b1-b17b-a06c4df25988)
**After**
![after](https://github.com/jenkinsci/cloud-stats-plugin/assets/49242855/ef47327d-f99f-4c0b-bee8-84e511210506)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
