### PR TITLE
Use Jenkinsfile from archetype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,11 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  forkCount: '1C',
-  // Container agents start faster and are easier to administer
-  useContainerAgent: true,
-  // Show failures on all configurations
-  failFast: false,
-  // Test Java 11 with minimum Jenkins version
-  // Test Java 17 with a more recent version
-  // Test Java 21 with a more recent version
+  forkCount: '1C', // Run a JVM per core in tests
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
-    [platform: 'linux',   jdk: '17'],
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
-    [platform: 'windows', jdk: '17', jenkins: '2.389'],
-  ]
-)
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Use Jenkinsfile from archetype

Use the Jenkinsfile from the plugin archetype in order to reduce differences throughout the Jenkins organization.

This intentionally reduces CI costs by running tests in fewer configurations.  It intentionally skips tests on Java 11 because we are compiling to Java 11 byte code and testing on Java 21 (Linux) and Java 17 (Windows) with the Java 11 byte code.  It intentionally removes the Jenkins version specific tests because after they have passed once, they almost never fail in later tests.

The Jenkinsfile from the plugin archetype is extended to run tests in parallel in order to reduce the time and cost of tests.

https://github.com/jenkinsci/archetypes/issues/650 describes the alternatives for Jenkinsfile configurations.

### Testing done

Plugin archetype Jenkinsfile has been verified in many repositories.  No additional testing performed here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
