### PR TITLE
Use newer spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
+    <!-- TODO: Remove when plugin pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
     <useBeta>true</useBeta>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -2,8 +2,15 @@
 <FindBugsFilter>
   <!--
     Exclusions in this section have been triaged and determined to be
-    false positives.
+    false positives or not relevant for this plugin.
   -->
+  <Match>
+    <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    <Or>
+      <Class name="org.jenkinsci.plugins.cloudstats.CloudStatistics" />
+      <Class name="org.jenkinsci.plugins.cloudstats.CyclicThreadSafeCollection" />
+    </Or>
+  </Match>
   <Match>
     <Bug pattern="SE_NO_SERIALVERSIONID" />
     <Or>


### PR DESCRIPTION
## Use newer spotbugs

Suppresses the new spotbugs warnings because Jenkins plugins are generally not at risk for finalizer attacks.

### Testing done

Confirmed that spotbugs is silent with latest plugin version.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
