### PR TITLE
Omit spotbugs CT_CONSTRUCTOR_THROWS visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,9 @@
     <!-- TODO: Remove when plugin pom is using this version or newer -->
     <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
     <useBeta>true</useBeta>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -5,13 +5,6 @@
     false positives or not relevant for this plugin.
   -->
   <Match>
-    <Bug pattern="CT_CONSTRUCTOR_THROW" />
-    <Or>
-      <Class name="org.jenkinsci.plugins.cloudstats.CloudStatistics" />
-      <Class name="org.jenkinsci.plugins.cloudstats.CyclicThreadSafeCollection" />
-    </Or>
-  </Match>
-  <Match>
     <Bug pattern="SE_NO_SERIALVERSIONID" />
     <Or>
       <Class name="org.jenkinsci.plugins.cloudstats.ProvisioningActivity$Id" />


### PR DESCRIPTION
From https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

> Discussion in spotbugs/spotbugs#2695
> https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
> seems to relate to libraries used with SecurityManager which is dead
> and certainly does not apply to Jenkins; we do not expect untrusted code
> to be running inside the controller JVM, and it does not seem plausible
> that finalizer abuse would happen by accident.
