### PR TITLE
Use "one-column" layout for results

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cloudstats/CloudStatistics/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/cloudstats/CloudStatistics/index.groovy
@@ -40,7 +40,7 @@ style("""
         }
 """)
 
-l.layout(permission: stats.getRequiredPermission()) {
+l.layout(permission: stats.getRequiredPermission(), type:"one-column") {
     l.header(title: stats.displayName)
     l.main_panel {
         h1(stats.displayName)


### PR DESCRIPTION
The change proposed makes use of the "one-column" layout, like the embeddable build status, as seen in https://ci.jenkins.io/job/Core/job/jenkins/job/master/badge/, to remove the unused sidepanel:

![Screenshot 2024-01-03 at 15 17 59](https://github.com/jenkinsci/cloud-stats-plugin/assets/13383509/ca49d733-2073-4226-9ed8-3efe8520bbbe)
