### PR TITLE
Rely on spotbugs version from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,6 @@
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <!-- TODO: Remove when plugin pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
-    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
     <useBeta>true</useBeta>


### PR DESCRIPTION
## Rely on spotbugs version from parent pom

The spotbugs version override has not been needed for several versions of the parent pom.

### Testing done

Confirmed that `mvn clean -DskipTests verify` is clean before and after this change.  The change does not alter any production code.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
