### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
@@ -55,8 +55,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2982.vdce2153031a_0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

As of 19 Apr 2024, 86% of the installations of the most recent release (336.v788e4055508b_ - released 3 months ago) are using Jenkins 2.426.3 or newer.  64% of all installations of the plugin are using the most recent release, 336.v788e4055508b_.  Users that are upgrading the plugin are already using Jenkins 2.426.3.

Jenkins 2.426.3 is the first version with the fix for https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314, the arbitrary file read vulnerability through the CLI can lead to RCE. It is a very good choice as a minimum Jenkins version.

Jenkins 2.426.3 is one of the versions suggested by https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

Updates the plugin bill of matertials for Jenkins 2.426.x as well

### Testing done

Regularly used already in my Jenkins 2.440.3 installation.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
