### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloud-stats-plugin</gitHubRepo>
-    <jenkins.version>2.426.3</jenkins.version>
+    <jenkins.baseline>2.440</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <surefire.useFile>false</surefire.useFile>
@@ -55,8 +56,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3221.ve8f7b_fdd149d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

The [plugin installation statistics](https://stats.jenkins.io/pluginversions/cloud-stats.html) show that Jenkins 2.440.3 or newer is already used by 80% of the installations of the most recent release and the most recent release is used in 75% of all installations.  Jenkins 2.440.3 also includes a security fix that is good for users to deploy.

BOM updates have stopped for bom-2.426.x so this will also continue updating plugin dependencies by switching to a bom version that is still receiving updates.

Change also removes the duplication of the Jenkins baseline as has been done recently in the plugin archetype.  Refer to:

* https://github.com/jenkinsci/archetypes/pull/737

### Testing done

Confirmed that `mvn clean verify` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
