### PR TITLE
Expose plugin information though api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ attached states is propagated to the phase execution and activity level. (If
 agent fails to launch, and exception will be attached explaining why the
 launch phase and thus the whole activity has failed).
 
+## Remote API
+
+The plugin now exposes the collected provisioning activities through the
+standard Jenkins remote API from the Cloud Statistics management page.
+
+- JSON: `/manage/cloud-stats/api/json?depth=2`
+- XML: `/manage/cloud-stats/api/xml?depth=2`
+
+The exported data includes provisioning activity identifiers and names,
+timestamps, current phase, overall status, phase execution details, and
+attachments such as provisioning errors and exception stack traces.
+
+Use `depth=2` to include nested phase executions and their attachments in the
+response.
+
 ## Integrating cloud plugin with cloud-stats-plugin
 
 In order for cloud-stats plugin to recognize provisioning activity to track,

--- a/README.md
+++ b/README.md
@@ -34,8 +34,18 @@ launch phase and thus the whole activity has failed).
 The plugin now exposes the collected provisioning activities through the
 standard Jenkins remote API from the Cloud Statistics management page.
 
-- JSON: `/manage/cloud-stats/api/json?depth=2`
-- XML: `/manage/cloud-stats/api/xml?depth=2`
+The API is available under both of the following URL forms:
+
+- Management page route:
+  - JSON: `/manage/cloud-stats/api/json?depth=2`
+  - XML: `/manage/cloud-stats/api/xml?depth=2`
+- Direct cloud-stats route:
+  - JSON: `/cloud-stats/api/json?depth=2`
+  - XML: `/cloud-stats/api/xml?depth=2`
+
+These routes expose the same data; if you are linking from the Jenkins
+management UI, use the management page route, and if you are querying the
+plugin endpoint directly, use the direct cloud-stats route.
 
 The exported data includes provisioning activity identifiers and names,
 timestamps, current phase, overall status, phase execution details, and

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
@@ -66,8 +66,11 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /** Statistics of provisioning activities. */
+@ExportedBean
 @Extension
 public class CloudStatistics extends ManagementLink implements Saveable, StaplerProxy {
 
@@ -218,6 +221,7 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         return "STATUS";
     }
 
+    @Exported(inline = true)
     public List<ProvisioningActivity> getActivities() {
         synchronized (active) {
             ArrayList<ProvisioningActivity> out = new ArrayList<>(active.size() + log.size());
@@ -225,6 +229,10 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
             out.addAll(active);
             return out;
         }
+    }
+
+    public hudson.model.Api getApi() {
+        return new hudson.model.Api(this);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
@@ -235,10 +235,20 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
      * Exposes provisioning activity data through the standard Jenkins remote API
      * ({@code /manage/cloud-stats/api/json} and {@code /manage/cloud-stats/api/xml}).
      *
-     * <p>Access is gated by {@link Jenkins#SYSTEM_READ}, the same permission that guards the
-     * Cloud Statistics management page and its existing HTML views (which already render all
-     * activity data, including exception stack traces). No additional permission is required
-     * because the API surface is intentionally equivalent to what the UI already exposes.
+     * <p><strong>Permission model:</strong> Access is enforced by {@link #getTarget()}, which
+     * checks {@link Jenkins#SYSTEM_READ} before Stapler dispatches any route under this object —
+     * including both the HTML management pages and this API endpoint. {@code SYSTEM_READ} is
+     * therefore the single, consistent gate for everything this class serves.
+     *
+     * <p><strong>Stack-trace exposure:</strong> The exported data includes
+     * {@link PhaseExecutionAttachment.ExceptionAttachment#getText()} (full exception stack traces).
+     * This is intentional and not a new exposure: the identical text is already rendered as HTML
+     * at {@code /manage/cloud-stats/activity/{fingerprint}/phase/{phase}/attachment/exception/}
+     * (see {@code ExceptionAttachment/_index.jelly}) for any caller who holds {@code SYSTEM_READ}.
+     * Requiring a stronger permission for the API endpoint but not for the HTML page would be
+     * inconsistent — the same data would remain accessible by simply navigating the UI.
+     * Organisations that consider {@code SYSTEM_READ} too broad for this data should tighten
+     * that permission grant rather than split the access model between UI and API.
      */
     public hudson.model.Api getApi() {
         return new hudson.model.Api(this);

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/CloudStatistics.java
@@ -231,6 +231,15 @@ public class CloudStatistics extends ManagementLink implements Saveable, Stapler
         }
     }
 
+    /**
+     * Exposes provisioning activity data through the standard Jenkins remote API
+     * ({@code /manage/cloud-stats/api/json} and {@code /manage/cloud-stats/api/xml}).
+     *
+     * <p>Access is gated by {@link Jenkins#SYSTEM_READ}, the same permission that guards the
+     * Cloud Statistics management page and its existing HTML views (which already render all
+     * activity data, including exception stack traces). No additional permission is required
+     * because the API surface is intentionally equivalent to what the UI already exposes.
+     */
     public hudson.model.Api getApi() {
         return new hudson.model.Api(this);
     }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -50,6 +52,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * considered completed as soon as the next phase begins. IOW, despite the fact the agent already
  * started launching, plugin can still append provisioning log.
  */
+@ExportedBean
 public final class PhaseExecution implements ModelObject {
     private final @NonNull List<PhaseExecutionAttachment> attachments = new CopyOnWriteArrayList<>();
     private final long started;
@@ -64,6 +67,7 @@ public final class PhaseExecution implements ModelObject {
         this.phase = phase;
     }
 
+    @Exported
     public @NonNull List<PhaseExecutionAttachment> getAttachments() {
         return Collections.unmodifiableList(attachments);
     }
@@ -78,6 +82,7 @@ public final class PhaseExecution implements ModelObject {
         return out;
     }
 
+    @Exported
     public @NonNull ProvisioningActivity.Status getStatus() {
         ProvisioningActivity.Status status = ProvisioningActivity.Status.OK;
         for (PhaseExecutionAttachment a : getAttachments()) {
@@ -92,10 +97,12 @@ public final class PhaseExecution implements ModelObject {
         return new Date(started);
     }
 
+    @Exported
     public long getStartedTimestamp() {
         return started;
     }
 
+    @Exported
     public @NonNull ProvisioningActivity.Phase getPhase() {
         return phase;
     }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecution.java
@@ -31,11 +31,11 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Phase execution record.

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
@@ -33,8 +33,11 @@ import java.io.FileNotFoundException;
 import java.io.Serializable;
 import java.nio.file.NoSuchFileException;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity.Status;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /** Additional information attached to the {@link PhaseExecution}. */
+@ExportedBean
 public class PhaseExecutionAttachment implements Action, Serializable {
 
     private final @NonNull ProvisioningActivity.Status status;
@@ -53,11 +56,13 @@ public class PhaseExecutionAttachment implements Action, Serializable {
      *     or {@link Status#FAIL} in case provisioning failed with this attachment explaining the
      *     cause.
      */
+    @Exported
     public @NonNull ProvisioningActivity.Status getStatus() {
         return status;
     }
 
     /** Single line description of the attachment nature. */
+    @Exported
     public @NonNull String getTitle() {
         return title.replaceAll("\n", " ");
     }
@@ -83,6 +88,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
         return null;
     }
 
+    @ExportedBean
     public static final class ExceptionAttachment extends PhaseExecutionAttachment {
 
         public static final long serialVersionUID = 0;
@@ -146,6 +152,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
             return throwable;
         }
 
+        @Exported
         public @NonNull String getText() {
             return text;
         }

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/PhaseExecutionAttachment.java
@@ -64,7 +64,7 @@ public class PhaseExecutionAttachment implements Action, Serializable {
     /** Single line description of the attachment nature. */
     @Exported
     public @NonNull String getTitle() {
-        return title.replaceAll("\n", " ");
+        return title.replace('\n', ' ');
     }
 
     @Override
@@ -152,6 +152,15 @@ public class PhaseExecutionAttachment implements Action, Serializable {
             return throwable;
         }
 
+        /**
+         * Full stack trace of the exception.
+         *
+         * <p>Exported over the remote API at the same {@link hudson.security.Permission} level as
+         * the Cloud Statistics management page ({@link jenkins.model.Jenkins#SYSTEM_READ}), which
+         * already renders this information as HTML. No additional redaction is applied here because
+         * any caller who can reach {@code /manage/cloud-stats/api/} can equally reach the
+         * attachment's own HTML page at the same permission level.
+         */
         @Exported
         public @NonNull String getText() {
             return text;

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -29,8 +29,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Util;
 import hudson.model.ModelObject;
 import java.io.Serializable;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -39,6 +37,8 @@ import java.util.Objects;
 import javax.annotation.concurrent.GuardedBy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Record of provisioning attempt lifecycle.

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -269,7 +269,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     @Exported(inline = true)
     public @NonNull Map<Phase, PhaseExecution> getPhaseExecutions() {
         synchronized (progress) {
-            return new LinkedHashMap<>(progress);
+            return Collections.unmodifiableMap(new LinkedHashMap<>(progress));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -268,8 +268,9 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      */
     @Exported(inline = true)
     public @NonNull Map<Phase, PhaseExecution> getPhaseExecutions() {
-        // progress is threadsafe here
-        return Collections.unmodifiableMap(progress);
+        synchronized (progress) {
+            return new LinkedHashMap<>(progress);
+        }
     }
 
     /** Get current {@link PhaseExecution}. */

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -29,6 +29,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Util;
 import hudson.model.ModelObject;
 import java.io.Serializable;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -43,6 +45,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @author ogondza.
  */
+@ExportedBean
 public final class ProvisioningActivity implements ModelObject, Comparable<ProvisioningActivity> {
 
     public static final String PREMATURE_COMPLETION_DETECTED =
@@ -87,6 +90,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      * <p>Used to a) uniquely identify the activity throughout the lifecycle and b) map
      * Computer/Node/PlannedNode to its cloud/template.
      */
+    @ExportedBean
     public static final class Id implements Serializable {
         private final @NonNull String cloudName;
         private final @CheckForNull String templateName;
@@ -134,6 +138,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         }
 
         /** Name of the cloud that initiated this activity. */
+        @Exported
         public @NonNull String getCloudName() {
             return cloudName;
         }
@@ -142,6 +147,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
          * Name of the template used to provision this agent. <code>null</code> if no further
          * distinction is needed except for cloud name.
          */
+        @Exported
         public @CheckForNull String getTemplateName() {
             return templateName;
         }
@@ -150,11 +156,13 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
          * Name of the agent to be provisioned by this activity. <code>null</code> if not known
          * ahead.
          */
+        @Exported
         public @CheckForNull String getNodeName() {
             return nodeName;
         }
 
         /** Unique fingerprint of this activity. */
+        @Exported
         public int getFingerprint() {
             return fingerprint;
         }
@@ -228,6 +236,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         this.name = name;
     }
 
+    @Exported
     public @NonNull Id getId() {
         return id;
     }
@@ -238,6 +247,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         }
     }
 
+    @Exported
     public long getStartedTimestamp() {
         synchronized (progress) {
             return progress.get(Phase.PROVISIONING).getStartedTimestamp();
@@ -256,6 +266,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      *
      * @return Map of {@link Phase} and nullable {@link PhaseExecution}.
      */
+    @Exported(inline = true)
     public @NonNull Map<Phase, PhaseExecution> getPhaseExecutions() {
         // progress is threadsafe here
         return Collections.unmodifiableMap(progress);
@@ -289,6 +300,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     }
 
     /** Get current {@link Phase}. */
+    @Exported
     public @NonNull Phase getCurrentPhase() {
         return getCurrentPhaseExecution().getPhase();
     }
@@ -298,6 +310,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
      *
      * <p>It is the works status of any of the phases, OK by default.
      */
+    @Exported
     public @NonNull Status getStatus() {
         synchronized (progress) {
             Status status = Status.OK;
@@ -378,6 +391,7 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
         execution.attach(attachment);
     }
 
+    @Exported
     public @CheckForNull String getName() {
         synchronized (id) {
             return name;

--- a/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
+++ b/src/main/java/org/jenkinsci/plugins/cloudstats/ProvisioningActivity.java
@@ -262,14 +262,23 @@ public final class ProvisioningActivity implements ModelObject, Comparable<Provi
     }
 
     /**
-     * Get sorted mapping of all phase executions.
+     * Get a snapshot of phase executions for phases that have already started.
      *
-     * @return Map of {@link Phase} and nullable {@link PhaseExecution}.
+     * <p>Phases that have not yet been entered are absent from the returned map. The iteration
+     * order follows declaration order of {@link Phase}.
+     *
+     * @return Unmodifiable map of started {@link Phase}s to their (non-null) {@link PhaseExecution}.
      */
     @Exported(inline = true)
     public @NonNull Map<Phase, PhaseExecution> getPhaseExecutions() {
         synchronized (progress) {
-            return Collections.unmodifiableMap(new LinkedHashMap<>(progress));
+            LinkedHashMap<Phase, PhaseExecution> snapshot = new LinkedHashMap<>(progress.size());
+            for (Map.Entry<Phase, PhaseExecution> entry : progress.entrySet()) {
+                if (entry.getValue() != null) {
+                    snapshot.put(entry.getKey(), entry.getValue());
+                }
+            }
+            return Collections.unmodifiableMap(snapshot);
         }
     }
 

--- a/src/main/resources/lib/cloudstats/attempts.groovy
+++ b/src/main/resources/lib/cloudstats/attempts.groovy
@@ -66,7 +66,6 @@ table(class: "sortable jenkins-table", width: "100%", id: "cloud-stat-grid") {
   tbody {
   acts.reverseEach { ProvisioningActivity activity ->
     def activityStatus = activity.status
-    List<PhaseExecution> executions = new ArrayList<>(activity.phaseExecutions.values())
     tr("class": "status-${activityStatus}") {
       td(activity.id.cloudName)
       td(activity.id.templateName)
@@ -78,10 +77,12 @@ table(class: "sortable jenkins-table", width: "100%", id: "cloud-stat-grid") {
           text(n)
         }
       }
-      td(data: executions[0].startedTimestamp) {
-        text(df.format(executions[0].started))
+      PhaseExecution provisioningExecution = activity.getPhaseExecution(ProvisioningActivity.Phase.PROVISIONING)
+      td(data: provisioningExecution.startedTimestamp) {
+        text(df.format(provisioningExecution.started))
       }
-      for (PhaseExecution execution : executions) {
+      for (ProvisioningActivity.Phase phase : ProvisioningActivity.Phase.values()) {
+        PhaseExecution execution = activity.getPhaseExecution(phase)
         if (execution == null) {
           td() // empty cell
           continue

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
@@ -645,6 +645,48 @@ class CloudStatisticsTest {
         }
     }
 
+    @Test
+    void restApi() throws Exception {
+        CloudStatistics cs = CloudStatistics.get();
+        ProvisioningListener provisioningListener = ProvisioningListener.get();
+
+        Id failId = new Id("MyCloud", "broken-template", "fail-agent");
+        provisioningListener.onStarted(failId);
+        provisioningListener.onFailure(failId, new Exception("ProvisioningFailed"));
+
+        Id okId = new Id("MyCloud", "working-template", "ok-agent");
+        ProvisioningActivity okActivity = provisioningListener.onStarted(okId);
+        Node slave = TrackedAgent.create(okId, j);
+        provisioningListener.onComplete(okId, slave);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
+
+        // Verify JSON API is accessible
+        Page page = wc.goTo("cloud-stats/api/json?depth=2", "application/json");
+        String json = page.getWebResponse().getContentAsString();
+
+        // Verify activities are present
+        assertThat(json, containsString("\"activities\""));
+        assertThat(json, containsString("MyCloud"));
+        assertThat(json, containsString("broken-template"));
+        assertThat(json, containsString("working-template"));
+
+        // Verify phase execution data
+        assertThat(json, containsString("PROVISIONING"));
+        assertThat(json, containsString("FAIL"));
+        assertThat(json, containsString("OK"));
+
+        // Verify exception attachment text is included
+        assertThat(json, containsString("ProvisioningFailed"));
+
+        // Verify XML API is also accessible
+        Page xmlPage = wc.goTo("cloud-stats/api/xml?depth=2", "application/xml");
+        String xml = xmlPage.getWebResponse().getContentAsString();
+        assertThat(xml, containsString("MyCloud"));
+        assertThat(xml, containsString("broken-template"));
+    }
+
     /** inline ${@link hudson.Functions#isWindows()} to avoid remote classloader issues */
     private boolean isWindows() {
         return java.io.File.pathSeparatorChar == ';';

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
@@ -705,16 +705,14 @@ class CloudStatisticsTest {
         provisioningListener.onStarted(new Id("cloud", "template", "agent"));
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                .grant(Jenkins.READ)
-                .everywhere()
-                .to("reader"));
+        j.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("reader"));
 
         JenkinsRule.WebClient userWc = j.createWebClient().login("reader", "reader");
         userWc.setThrowExceptionOnFailingStatusCode(false);
 
-
-        assertEquals(403, userWc.goTo("manage/cloud-stats/api/json").getWebResponse().getStatusCode());
+        assertEquals(
+                403, userWc.goTo("manage/cloud-stats/api/json").getWebResponse().getStatusCode());
         assertEquals(403, userWc.goTo("cloud-stats/api/json").getWebResponse().getStatusCode());
     }
 

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
@@ -647,7 +647,6 @@ class CloudStatisticsTest {
 
     @Test
     void restApi() throws Exception {
-        CloudStatistics cs = CloudStatistics.get();
         ProvisioningListener provisioningListener = ProvisioningListener.get();
 
         Id failId = new Id("MyCloud", "broken-template", "fail-agent");
@@ -655,36 +654,49 @@ class CloudStatisticsTest {
         provisioningListener.onFailure(failId, new Exception("ProvisioningFailed"));
 
         Id okId = new Id("MyCloud", "working-template", "ok-agent");
-        ProvisioningActivity okActivity = provisioningListener.onStarted(okId);
+        provisioningListener.onStarted(okId);
         Node slave = TrackedAgent.create(okId, j);
         provisioningListener.onComplete(okId, slave);
 
         JenkinsRule.WebClient wc = j.createWebClient();
         j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
 
-        // Verify JSON API is accessible
-        Page page = wc.goTo("cloud-stats/api/json?depth=2", "application/json");
-        String json = page.getWebResponse().getContentAsString();
+        // Verify JSON API is accessible at the documented /cloud-stats/api/... route
+        Page page1 = wc.goTo("cloud-stats/api/json?depth=2", "application/json");
+        String json1 = page1.getWebResponse().getContentAsString();
+        // Verify JSON API is accessible at the documented /manage/cloud-stats/api/... route
+        Page page2 = wc.goTo("manage/cloud-stats/api/json?depth=2", "application/json");
+        String json2 = page2.getWebResponse().getContentAsString();
 
         // Verify activities are present
-        assertThat(json, containsString("\"activities\""));
-        assertThat(json, containsString("MyCloud"));
-        assertThat(json, containsString("broken-template"));
-        assertThat(json, containsString("working-template"));
+        assertThat(json1, containsString("\"activities\""));
+        assertThat(json1, containsString("MyCloud"));
+        assertThat(json1, containsString("broken-template"));
+        assertThat(json1, containsString("working-template"));
+        assertThat(json2, containsString("\"activities\""));
+        assertThat(json2, containsString("MyCloud"));
+        assertThat(json2, containsString("broken-template"));
+        assertThat(json2, containsString("working-template"));
 
         // Verify phase execution data
-        assertThat(json, containsString("PROVISIONING"));
-        assertThat(json, containsString("FAIL"));
-        assertThat(json, containsString("OK"));
+        assertThat(json1, containsString("PROVISIONING"));
+        assertThat(json1, containsString("FAIL"));
+        assertThat(json1, containsString("OK"));
 
         // Verify exception attachment text is included
-        assertThat(json, containsString("ProvisioningFailed"));
+        assertThat(json1, containsString("ProvisioningFailed"));
 
-        // Verify XML API is also accessible
-        Page xmlPage = wc.goTo("cloud-stats/api/xml?depth=2", "application/xml");
-        String xml = xmlPage.getWebResponse().getContentAsString();
-        assertThat(xml, containsString("MyCloud"));
-        assertThat(xml, containsString("broken-template"));
+        // Verify XML API is also accessible at the documented /manage/cloud-stats/api/... route
+        Page xmlPage1 = wc.goTo("manage/cloud-stats/api/xml?depth=2", "application/xml");
+        String xml1 = xmlPage1.getWebResponse().getContentAsString();
+        assertThat(xml1, containsString("MyCloud"));
+        assertThat(xml1, containsString("broken-template"));
+
+        // Verify XML API is also accessible at the documented /cloud-stats/api/... route
+        Page xmlPage2 = wc.goTo("cloud-stats/api/xml?depth=2", "application/xml");
+        String xml2 = xmlPage2.getWebResponse().getContentAsString();
+        assertThat(xml2, containsString("MyCloud"));
+        assertThat(xml2, containsString("broken-template"));
     }
 
     /** inline ${@link hudson.Functions#isWindows()} to avoid remote classloader issues */

--- a/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cloudstats/CloudStatisticsTest.java
@@ -699,6 +699,25 @@ class CloudStatisticsTest {
         assertThat(xml2, containsString("broken-template"));
     }
 
+    @Test
+    void restApiDeniedWithoutSystemRead() throws Exception {
+        ProvisioningListener provisioningListener = ProvisioningListener.get();
+        provisioningListener.onStarted(new Id("cloud", "template", "agent"));
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ)
+                .everywhere()
+                .to("reader"));
+
+        JenkinsRule.WebClient userWc = j.createWebClient().login("reader", "reader");
+        userWc.setThrowExceptionOnFailingStatusCode(false);
+
+
+        assertEquals(403, userWc.goTo("manage/cloud-stats/api/json").getWebResponse().getStatusCode());
+        assertEquals(403, userWc.goTo("cloud-stats/api/json").getWebResponse().getStatusCode());
+    }
+
     /** inline ${@link hudson.Functions#isWindows()} to avoid remote classloader issues */
     private boolean isWindows() {
         return java.io.File.pathSeparatorChar == ';';


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
# Expose plugin information though api

The plugin now exposes the collected provisioning activities through the standard Jenkins remote API from the Cloud Statistics management page.
- JSON: `/manage/cloud-stats/api/json?depth=2`
- XML: `/manage/cloud-stats/api/xml?depth=2`

The exported data includes provisioning activity identifiers and names, timestamps, current phase, overall status, phase execution details, and attachments such as provisioning errors and exception stack traces. Additional path parameter (`depth=2`) can be used to include nested phase executions and their attachments in the
response.

Related with issue: https://github.com/jenkinsci/cloud-stats-plugin/issues/24


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Confirmed that automated tests pass and integrated new test.

- Json api endpoint with no activity:
<img width="541" height="191" alt="Screenshot 2026-04-15 at 14 46 52" src="https://github.com/user-attachments/assets/90366cb2-1445-4123-8da3-cac7a44d9aa8" />

- Json api endpoint with activity:
<img width="675" height="920" alt="Screenshot 2026-04-15 at 15 02 32" src="https://github.com/user-attachments/assets/c50bd0f5-180d-42fd-8e32-82bb9f1a3037" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
